### PR TITLE
Fix date errors created when running without market filepath

### DIFF
--- a/fgem/markets.py
+++ b/fgem/markets.py
@@ -46,7 +46,7 @@ class TabularPowerMarket:
                 print("Slow formating of datetime while loading of wholesale market data ... ")
                 self.df.Date = pd.to_datetime(self.df.Date)
         else:
-            self.df = time_init + pd.DataFrame(np.cumsum(L * 8760 * [timedelta(hours=1)]), columns=["Date"])
+            self.df = pd.DataFrame(pd.date_range(start=time_init, end=time_init + pd.DateOffset(years = L) - pd.DateOffset(hours = 1), freq='h'), columns=["Date"])
             # self.df.set_index("Date", inplace=True)
             self.df["price"] = energy_price
             self.df["recs_price"] = 30


### PR DESCRIPTION
Fixes two errors. 

1. Line 48 uses pd.cumsum to create date series, which means that the first hour (hour 0) is skipped. By switching to pd.date_range we include the first hour. 

2. Line 48 adds 8760 hours, regardless of whether the year processed is a leap year. If the initial year is a leap year, the final day of the year will not be added. Then, line 69 directly deletes any leap days, further reducing the number of hours. By setting the end date exactly one year later, and subtracting one hour, this will create an appropriately sized data frame.

Note: I haven't thoroughly tested this, please confirm that everything runs as expected first.